### PR TITLE
Tags rearrange themselves on layoutSubviews

### DIFF
--- a/AMTagListView/AMTagListView.m
+++ b/AMTagListView/AMTagListView.m
@@ -36,6 +36,14 @@
 	return self;
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    // If tags are added in a view controller's viewDidLoad, the tags need to be
+    // rearranged when the screen geometry is fully known.
+    [self rearrangeTags];
+}
+
 - (void)setup
 {
 	// Default margins


### PR DESCRIPTION
HI Andrea,

I was having an issue with AMTagListView in the following case: in my view controller's `viewDidLoad`, I have a list of tags that I want to add, so I add them one by one using the `addTagView` method. On an iPad, the tags show up aligned incorrectly:

![ios simulator screen shot jul 1 2014 12 27 12 pm](https://cloud.githubusercontent.com/assets/563375/3448147/ba4e6a78-0155-11e4-9cf9-d07ed866347e.png)

If I add or remove a tag, they rearrange themselves correctly.

I've proposed a solution where the private method `rearrangeTags` is called during `layoutSubviews`. This resolves this issue.
