### PR TITLE
Remove Tag and Hole from drawRect when tagLength == 0

### DIFF
--- a/AMTagListView/AMTagListView.m
+++ b/AMTagListView/AMTagListView.m
@@ -72,19 +72,15 @@
 
 - (void)addTag:(NSString*)text andRearrange:(BOOL)rearrange
 {
-	UIFont* font = [[AMTagView appearance] textFont] ? [[AMTagView appearance] textFont] : kDefaultFont;
-	CGSize size = [text sizeWithAttributes:@{NSFontAttributeName: font}];
-	float padding = [[AMTagView appearance] textPadding] ? [[AMTagView appearance] textPadding] : kDefaultTextPadding;
-	float tagLength = [[AMTagView appearance] tagLength] ? [[AMTagView appearance] tagLength] : kDefaultTagLength;
-	
-	size.width = (int)size.width + padding * 2 + tagLength;
-	size.height = (int)size.height + padding;
-	size.width = MIN(size.width, self.frame.size.width - self.marginX * 2);
-    
-	AMTagView* tagView = [[AMTagView alloc] initWithFrame:(CGRect){0, 0, size.width, size.height}];
+	AMTagView* tagView = [[AMTagView alloc] initWithFrame:CGRectZero];
 	[tagView setupWithText:text];
+
+    CGRect frame = tagView.frame;
+    frame.size.width = MIN(frame.size.width, self.frame.size.width - self.marginX * 2);
+    tagView.frame = frame;
+
 	[self.tags addObject:tagView];
-	
+
     if (rearrange) {
         [self rearrangeTags];
     }
@@ -101,14 +97,14 @@
 	CGSize size = [tagView.tagText sizeWithAttributes:@{NSFontAttributeName: font}];
 	float padding = [[[tagView class] appearance] textPadding] ? [[[tagView class] appearance] textPadding] : kDefaultTextPadding;
 	float tagLength = [[[tagView class] appearance] tagLength] ? [[[tagView class] appearance] tagLength] : kDefaultTagLength;
-	
+
 	size.width = (int)size.width + padding * 2 + tagLength;
 	size.height = (int)size.height + padding;
 	size.width = MIN(size.width, self.frame.size.width - self.marginX * 2);
-    
+
     tagView.frame = (CGRect){0, 0, size.width, size.height};
 	[self.tags addObject:tagView];
-	
+
     if (rearrange) {
         [self rearrangeTags];
     }
@@ -161,7 +157,7 @@
 				maxY = MAX(maxY, obj.frame.origin.y);
 			}
 		}];
-		
+
 		[self.subviews enumerateObjectsUsingBlock:^(UIView* obj, NSUInteger idx, BOOL *stop) {
 			if ([obj isKindOfClass:[AMTagView class]]) {
 				if (obj.frame.origin.y == maxY) {
@@ -169,7 +165,7 @@
 				}
 			}
 		}];
-		
+
 		// Go to a new line if the tag won't fit
 		if (size.width + maxX > (self.frame.size.width - self.marginX)) {
 			maxY += size.height + self.marginY;
@@ -178,7 +174,7 @@
 		obj.frame = (CGRect){maxX + self.marginX, maxY, size.width, size.height};
 		[self addSubview:obj];
 	}];
-	
+
 	[self setContentSize:(CGSize){self.frame.size.width, maxY + size.height +self.marginY}];
 }
 


### PR DESCRIPTION
I also fixed how the default UIAppearance values were being loaded. That fixes the problem in which I'd have <code>tagLength = 0</code> but the following code would override it to the default:

```
float tagLength = [[AMTagView appearance] tagLength] ? [[AMTagView appearance] tagLength] : kDefaultTagLength;
```

Since I had set <code>[[AMTagView appearance] tagLength]</code> to <code>0</code> somewhere in my own code, the ternary if would load the value of <code>kDefaultTagLength</code> when adding a new tag.
