### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/SwiftDemo/Pods/AMTagListView/README.md
+++ b/SwiftDemo/Pods/AMTagListView/README.md
@@ -1,15 +1,15 @@
-#AMTagListView
+# AMTagListView
 
 [![Build Status](https://travis-ci.org/andreamazz/AMTagListView.png)](https://travis-ci.org/andreamazz/AMTagListView)
 [![Cocoapods](https://cocoapod-badges.herokuapp.com/v/AMTagListView/badge.png)](http://cocoapods.org/?q=amtaglistview)
 
 UIScrollView subclass that allows to add a list of highly customizable tags. You can customize colors, border radius, and the tail of the tag. Tags can be added in bulk or dinamically one by one. The newly inserted tag will automatically arrange itself inside the scrollview.
 
-##Screenshot
+## Screenshot
 
 ![AMTagListView](https://raw.githubusercontent.com/andreamazz/AMTagListView/master/screenshot.gif)
 
-##Setup with Cocoapods
+## Setup with Cocoapods
 
 * Add ```pod 'AMTagListView'``` to your Podfile
 * Run ```pod install```
@@ -17,7 +17,7 @@ UIScrollView subclass that allows to add a list of highly customizable tags. You
 * Import ```AMTagListView.h``` in your controller
 * Create a new AMTagListView with Storyboards or via code.
 
-##Usage
+## Usage
 ```objc
 // Init 
 AMTagListView *tagListView = [[AMTagListView alloc] initWithFrame:frame];
@@ -30,13 +30,13 @@ AMTagListView *tagListView = [[AMTagListView alloc] initWithFrame:frame];
 [self.tagListView addTags:@[@"my tag", @"some tag"]];
 ```
 
-##Arranging tags
+## Arranging tags
 The tags are rearranged when you use the method calls listed above. You can also avoid the auto-rearrange by using the `andRearrange:` versions of such methods. This is useful when adding a big batch of tags. When you do so you must force the rearrange action manually:
 ```
 [self.tagListView rearrangeTags];
 ```
 
-##Appearance
+## Appearance
 Use the AMTagView's UIAppearance selectors to customize its appearance:
 ```objc
 // Tag's corner radius
@@ -67,17 +67,17 @@ Use the AMTagView's UIAppearance selectors to customize its appearance:
 [[AMTagView appearance] setInnerTagColor:UIColor]
 ```
 
-##Test
+## Test
 
 To run the test suite, launch `pod install` inside the `Tests` folder, and run the rake task in the root.
 
-##Using this library?
+## Using this library?
 
 Please let me know! I'll be glad to link your project here.
 
 
 
-#MIT License
+# MIT License
 
 	Copyright (c) 2014 Andrea Mazzini. All rights reserved.
 

--- a/TagListViewDemo/Pods/Expecta/README.md
+++ b/TagListViewDemo/Pods/Expecta/README.md
@@ -1,4 +1,4 @@
-#Expecta
+# Expecta
 
 [![Build Status](http://img.shields.io/travis/specta/expecta/master.svg?style=flat)](https://travis-ci.org/specta/expecta)
 [![Pod Version](http://img.shields.io/cocoapods/v/Expecta.svg?style=flat)](http://cocoadocs.org/docsets/Expecta/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
